### PR TITLE
ユーザーテーブルとポストテーブルの紐づけ

### DIFF
--- a/src/app/Http/Controllers/Back/PostController.php
+++ b/src/app/Http/Controllers/Back/PostController.php
@@ -16,7 +16,7 @@ class PostController extends Controller
      */
     public function index()
     {
-        $posts = Post::latest('id')->paginate(20);
+        $posts = Post::with('user')->latest('id')->paginate(20);
         return view('back.posts.index', compact('posts'));
     }
 

--- a/src/app/Models/Post.php
+++ b/src/app/Models/Post.php
@@ -46,4 +46,13 @@ class Post extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    protected static function boot()
+    {
+        parent::boot();
+    
+        self::saving(function($post) {
+            $post->user_id = \Auth::id();
+        });
+    }
 }

--- a/src/app/Models/Post.php
+++ b/src/app/Models/Post.php
@@ -41,4 +41,9 @@ class Post extends Model
     {
         return $this->published_at->format('Y年m月d日');
     }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/src/database/factories/PostFactory.php
+++ b/src/database/factories/PostFactory.php
@@ -26,6 +26,7 @@ class PostFactory extends Factory
             'body' => $this->faker->realText(rand(100,200)),
             'is_public' => $this->faker->boolean(90),
             'published_at' => $random_date,
+            'user_id' => $this->faker->numberBetween(1,3),
             'created_at' => $random_date,
             'updated_at' => $random_date
         ];

--- a/src/database/migrations/2022_09_09_164037_create_posts_table.php
+++ b/src/database/migrations/2022_09_09_164037_create_posts_table.php
@@ -19,6 +19,7 @@ return new class extends Migration
             $table->text('body')->nullable();
             $table->boolean('is_public')->default(true)->comment('公開・非公開');
             $table->dateTime('published_at')->default(DB::raw('CURRENT_TIMESTAMP'))->comment('公開日');
+            $table->foreignId('user_id')->constrained();
             $table->timestamps();
         });
     }

--- a/src/database/seeders/PostSeeder.php
+++ b/src/database/seeders/PostSeeder.php
@@ -15,6 +15,8 @@ class PostSeeder extends Seeder
      */
     public function run()
     {
-        Post::factory()->count(50)->create();
+        \Event::fakeFor(function () {
+            Post::factory()->count(50)->create();
+        });
     }
 }

--- a/src/resources/views/back/posts/edit.blade.php
+++ b/src/resources/views/back/posts/edit.blade.php
@@ -5,6 +5,20 @@ $title = '投稿編集';
  
 @section('content')
 <div class="card-header">投稿編集</div>
+<table class="table">
+    <tr>
+        <th>編集者</th>
+        <td>{{ $post->user->name }}</td>
+    </tr>
+    <tr>
+        <th>登録日時</th>
+        <td>{{ $post->created_at }}</td>
+    </tr>
+    <tr>
+        <th>編集日時</th>
+        <td>{{ $post->updated_at }}</td>
+    </tr>
+</table>
 <div class="card-body">
     {!! Form::model($post, [
         'route' => ['back.posts.update', $post],

--- a/src/resources/views/back/posts/index.blade.php
+++ b/src/resources/views/back/posts/index.blade.php
@@ -15,6 +15,7 @@ $title = '投稿一覧';
                     <th scope="col">タイトル</th>
                     <th scope="col" style="width: 4.3em">状態</th>
                     <th scope="col" style="width: 9em">公開日</th>
+                    <th scope="col" style="width: 12em">編集者</th>
                     <th scope="col" style="width: 12em">編集</th>
                 </tr>
             </thead>
@@ -25,6 +26,7 @@ $title = '投稿一覧';
                     <td>{{ $post->title }}</td>
                     <td>{{ $post->is_public_label }}</td>
                     <td>{{ $post->published_format }}</td>
+                    <td>{{ $post->user->name }}</td>
                     <td class="d-flex justify-content-center">
                         {{ link_to_route('front.posts.show', '詳細', $post, [
                             'class' => 'btn btn-secondary btn-sm m-1',


### PR DESCRIPTION
## 目的
モデルでリレーション設定をすることでポストからユーザーにアクセスできるようにしたい

## 実装内容
ポストテーブルに外部キーとしてuser_idを登録
モデルでリレーションの設定
投稿一覧・編集画面で編集者の項目の追加
クエリの大量発行を防ぐためにEagerLodigの実装

## 期待動作
ポストからユーザーにアクセスしてユーザーの情報を取得できる。
クエリの発行数が少なくなる

## 実行結果
投稿の一覧画面
![image](https://user-images.githubusercontent.com/107784486/189601084-808277d1-843e-4551-8c0b-d27ae6d7fc2b.png)

クエリの発行数
![image](https://user-images.githubusercontent.com/107784486/189601618-dbc6b7d7-b3e4-4d0c-a4e5-d31761afee24.png)

