### PR TITLE
タグの管理機能、タグごとに投稿を表示する実装

### DIFF
--- a/src/app/Http/Controllers/Back/PostController.php
+++ b/src/app/Http/Controllers/Back/PostController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Back;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\Post;
+use App\Models\Tag;
 use App\Http\Requests\PostRequest;
 
 class PostController extends Controller
@@ -27,7 +28,8 @@ class PostController extends Controller
      */
     public function create()
     {
-        return view('back.posts.create');
+        $tags = Tag::pluck('name', 'id')->toArray();
+        return view('back.posts.create', compact('tags'));
     }
 
     /**
@@ -39,6 +41,7 @@ class PostController extends Controller
     public function store(PostRequest $request)
     {
         $post = Post::create($request->all());
+        $post->tags()->attach($request->tags);
  
         if ($post) {
             return redirect()
@@ -70,7 +73,8 @@ class PostController extends Controller
      */
     public function edit(Post $post)
     {
-        return view('back.posts.edit', compact('post'));
+        $tags = Tag::pluck('name', 'id')->toArray();
+        return view('back.posts.edit', compact('post', 'tags'));
     }
 
     /**
@@ -82,6 +86,8 @@ class PostController extends Controller
      */
     public function update(PostRequest $request, Post $post)
     {
+        $post->tags()->sync($request->tags);
+
         if ($post->update($request->all())) {
             $flash = ['success' => 'データを更新しました。'];
         } else {
@@ -101,6 +107,8 @@ class PostController extends Controller
      */
     public function destroy(Post $post)
     {
+        $post->tags()->detach();
+
         if ($post->delete()) {
             $flash = ['success' => 'データを削除しました。'];
         } else {

--- a/src/app/Http/Controllers/Back/TagController.php
+++ b/src/app/Http/Controllers/Back/TagController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Back;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\Tag;
+use App\Http\Requests\TagRequest;
 
 class TagController extends Controller
 {
@@ -35,9 +36,19 @@ class TagController extends Controller
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function store(Request $request)
+    public function store(TagRequest $request)
     {
-        //
+        $tag = Tag::create($request->all());
+ 
+        if ($tag) {
+            return redirect()
+                ->route('back.tags.edit', $tag)
+                ->withSuccess('データを登録しました。');
+        } else {
+            return redirect()
+                ->route('back.tags.create')
+                ->withError('データの登録に失敗しました。');
+        }
     }
 
     /**
@@ -57,9 +68,9 @@ class TagController extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function edit($id)
+    public function edit(Tag $tag)
     {
-        //
+        return view('back.tags.edit', compact('tag'));
     }
 
     /**
@@ -69,9 +80,17 @@ class TagController extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, $id)
+    public function update(TagRequest $request, Tag $tag)
     {
-        //
+        if ($tag->update($request->all())) {
+            $flash = ['success' => 'データを更新しました。'];
+        } else {
+            $flash = ['error' => 'データの更新に失敗しました'];
+        }
+     
+        return redirect()
+            ->route('back.tags.edit', $tag)
+            ->with($flash);
     }
 
     /**
@@ -80,8 +99,16 @@ class TagController extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function destroy($id)
+    public function destroy(Tag $tag)
     {
-        //
+        if ($tag->delete()) {
+            $flash = ['success' => 'データを削除しました。'];
+        } else {
+            $flash = ['error' => 'データの削除に失敗しました'];
+        }
+     
+        return redirect()
+            ->route('back.tags.index')
+            ->with($flash);
     }
 }

--- a/src/app/Http/Controllers/Back/TagController.php
+++ b/src/app/Http/Controllers/Back/TagController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Http\Controllers\Back;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Models\Tag;
+
+class TagController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        $tags = Tag::latest('id')->paginate(20);
+        return view('back.tags.index', compact('tags'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        return view('back.tags.create');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/src/app/Http/Controllers/Front/PostController.php
+++ b/src/app/Http/Controllers/Front/PostController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Front;
 use App\Http\Requests\StorePostRequest;
 use App\Http\Requests\UpdatePostRequest;
 use App\Models\Post;
+use App\Models\Tag;
 
 class PostController extends Controller
 {
@@ -13,10 +14,12 @@ class PostController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function index()
+    public function index($tagSlug = null)
     {
-        $posts = Post::publicList();
-        return view('front.posts.index', compact('posts'));
+        $posts = Post::publicList($tagSlug);
+        $tags = Tag::all();
+
+        return view('front.posts.index', compact('posts', 'tags'));
     }
 
     /**

--- a/src/app/Http/Controllers/TagController.php
+++ b/src/app/Http/Controllers/TagController.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreTagRequest;
+use App\Http\Requests\UpdateTagRequest;
+use App\Models\Tag;
+
+class TagController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \App\Http\Requests\StoreTagRequest  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(StoreTagRequest $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  \App\Models\Tag  $tag
+     * @return \Illuminate\Http\Response
+     */
+    public function show(Tag $tag)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  \App\Models\Tag  $tag
+     * @return \Illuminate\Http\Response
+     */
+    public function edit(Tag $tag)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \App\Http\Requests\UpdateTagRequest  $request
+     * @param  \App\Models\Tag  $tag
+     * @return \Illuminate\Http\Response
+     */
+    public function update(UpdateTagRequest $request, Tag $tag)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \App\Models\Tag  $tag
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(Tag $tag)
+    {
+        //
+    }
+}

--- a/src/app/Http/Requests/PostRequest.php
+++ b/src/app/Http/Requests/PostRequest.php
@@ -28,6 +28,7 @@ class PostRequest extends FormRequest
             'body' => 'max:1000',
             'is_public' => 'required|numeric',
             'published_at' => 'required|date_format:Y-m-d H:i',
+            'tags.*' => 'numeric|exists:tags,id'
         ];
     }
 
@@ -38,6 +39,7 @@ class PostRequest extends FormRequest
             'body' => '内容',
             'is_public' => 'ステータス',
             'published_at' => '公開日',
+            'tags.*' => 'タグ'
         ];
     }
 }

--- a/src/app/Http/Requests/StoreTagRequest.php
+++ b/src/app/Http/Requests/StoreTagRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreTagRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/src/app/Http/Requests/TagRequest.php
+++ b/src/app/Http/Requests/TagRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TagRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'name' => 'required|max:50',
+            'slug' => ['required', 'max:50', new AlphaNumDash, Rule::unique('tags')->ignore($this->tag)]
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'name' => 'タグ名',
+            'slug' => 'スラッグ'
+        ];
+    }
+}

--- a/src/app/Http/Requests/TagRequest.php
+++ b/src/app/Http/Requests/TagRequest.php
@@ -3,6 +3,8 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use App\Rules\AlphaNumDash;
+use Illuminate\Validation\Rule;
 
 class TagRequest extends FormRequest
 {

--- a/src/app/Http/Requests/UpdateTagRequest.php
+++ b/src/app/Http/Requests/UpdateTagRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateTagRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/src/app/Models/Post.php
+++ b/src/app/Models/Post.php
@@ -24,9 +24,16 @@ class Post extends Model
         return $query->where('is_public', true);
     }
  
-    public function scopePublicList(Builder $query)
+    public function scopePublicList(Builder $query, string $tagSlug = null)
     {
+        if ($tagSlug) {
+            $query->whereHas('tags', function($query) use ($tagSlug) {
+                $query->where('slug', $tagSlug);
+            });
+        }
+
         return $query
+            ->with('tags')
             ->public()
             ->latest('published_at')
             ->paginate(10);

--- a/src/app/Models/Post.php
+++ b/src/app/Models/Post.php
@@ -55,4 +55,9 @@ class Post extends Model
             $post->user_id = \Auth::id();
         });
     }
+
+    public function tags()
+    {
+        return $this->belongsToMany(Tag::class);
+    }
 }

--- a/src/app/Models/Tag.php
+++ b/src/app/Models/Tag.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Tag extends Model
+{
+    use HasFactory;
+
+    public function posts()
+    {
+        return $this->belongsToMany(Post::class);
+    }
+}

--- a/src/app/Models/Tag.php
+++ b/src/app/Models/Tag.php
@@ -13,4 +13,8 @@ class Tag extends Model
     {
         return $this->belongsToMany(Post::class);
     }
+
+    protected $fillable = [
+        'slug', 'name'
+    ];
 }

--- a/src/app/Policies/TagPolicy.php
+++ b/src/app/Policies/TagPolicy.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Tag;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class TagPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any models.
+     *
+     * @param  \App\Models\User  $user
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function viewAny(User $user)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Tag  $tag
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function view(User $user, Tag $tag)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can create models.
+     *
+     * @param  \App\Models\User  $user
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function create(User $user)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Tag  $tag
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function update(User $user, Tag $tag)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Tag  $tag
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function delete(User $user, Tag $tag)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Tag  $tag
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function restore(User $user, Tag $tag)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Tag  $tag
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function forceDelete(User $user, Tag $tag)
+    {
+        //
+    }
+}

--- a/src/app/Rules/AlphaNumDash.php
+++ b/src/app/Rules/AlphaNumDash.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * 半角英数字-(ハイフン)・_(ダッシュ)のバリデーション
+ */
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class AlphaNumDash implements Rule
+{
+    /**
+     * Create a new rule instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        return (preg_match("/^[a-z0-9_-]+$/i", $value));
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return ':attributeは、半角英数字か-(ハイフン)・_(ダッシュ)を入力してください。';
+    }
+}

--- a/src/database/factories/TagFactory.php
+++ b/src/database/factories/TagFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Tag>
+ */
+class TagFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/src/database/migrations/2022_09_12_165855_create_tags_table.php
+++ b/src/database/migrations/2022_09_12_165855_create_tags_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->id();
+            $table->char('slug', 50)->unique();
+            $table->char('name', 50);
+            $table->timestamps();
+        });
+
+        Schema::create('post_tag', function (Blueprint $table) {
+            $table->increments('id');
+            $table->foreignId('post_id')->constrained();
+            $table->foreignId('tag_id')->constrained();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('post_tag');
+        Schema::dropIfExists('tags');
+    }
+};

--- a/src/database/seeders/DatabaseSeeder.php
+++ b/src/database/seeders/DatabaseSeeder.php
@@ -22,5 +22,6 @@ class DatabaseSeeder extends Seeder
         // ]);
         $this->call(UserSeeder::class);
         $this->call(PostSeeder::class);
+        $this->call(TagSeeder::class);
     }
 }

--- a/src/database/seeders/TagSeeder.php
+++ b/src/database/seeders/TagSeeder.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Faker\Factory as Faker;
+
+class TagSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        \DB::table('tags')->insert([
+            [
+                'name' => 'お知らせ',
+                'slug' => 'news',
+                'created_at' => now(),
+                'updated_at' => now()
+            ],[
+                'name' => 'リリース',
+                'slug' => 'release',
+                'created_at' => now(),
+                'updated_at' => now()
+            ],[
+                'name' => 'キャンペーン',
+                'slug' => 'campaign',
+                'created_at' => now(),
+                'updated_at' => now()
+            ]
+        ]);
+ 
+        $faker = Faker::create();
+        for ($i = 1; $i <= 50; $i++) {
+            \DB::table('post_tag')->insert([
+                'post_id' => $i,
+                'tag_id' => $faker->numberBetween(1,3)
+            ]);
+        }
+    }
+}

--- a/src/resources/views/back/posts/_form.blade.php
+++ b/src/resources/views/back/posts/_form.blade.php
@@ -67,6 +67,25 @@
         @enderror
     </div>
 </div>
+
+<div class="form-group row">
+    {!! Form::label('tags', 'タグ', ['class' => 'col-sm-2 control-label']) !!}
+    <div class="col-sm-10">
+        <div class="{{ $errors->has('tags.*') ? 'is-invalid' : '' }}">
+            @foreach ($tags as $key => $tag)
+                <div class="form-check form-check-inline">
+                    {!! Form::checkbox( 'tags[]', $key, null, ['class' => 'form-check-input', 'id' => 'tag'.$key]) !!}
+                    <label class="form-check-label" for="tag{{$key}}">{{ $tag }}</label>
+                </div>
+            @endforeach
+        </div>
+        @error('tags.*')
+            <span class="invalid-feedback" role="alert">
+                {{ $message }}
+            </span>
+        @enderror
+    </div>
+</div>
  
 <div class="form-group row">
     <div class="col-sm-10">

--- a/src/resources/views/back/tags/_form.blade.php
+++ b/src/resources/views/back/tags/_form.blade.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @var \App\Models\Tag $tag
+ */
+?>
+<div class="form-group row">
+    {{ Form::label('name', 'タグ名', ['class' => 'col-sm-2 col-form-label']) }}
+    <div class="col-sm-10">
+        {{ Form::text('name', null, [
+            'class' => 'form-control' . ($errors->has('name') ? ' is-invalid' : ''),
+            'required'
+        ]) }}
+        @error('name')
+            <div class="invalid-feedback">
+                {{ $message }}
+            </div>
+        @enderror
+    </div>
+</div>
+
+<div class="form-group row">
+    {{ Form::label('slug', 'スラッグ', ['class' => 'col-sm-2 col-form-label']) }}
+    <div class="col-sm-10">
+        {{ Form::text('slug', null, [
+            'class' => 'form-control' . ($errors->has('slug') ? ' is-invalid' : ''),
+            'required'
+        ]) }}
+        @error('slug')
+        <div class="invalid-feedback">
+            {{ $message }}
+        </div>
+        @enderror
+    </div>
+</div>
+
+<div class="form-group row">
+    <div class="col-sm-10">
+        <button type="submit" class="btn btn-primary">保存</button>
+        {{ link_to_route('back.tags.index', '一覧へ戻る', null, ['class' => 'btn btn-secondary']) }}
+    </div>
+</div>

--- a/src/resources/views/back/tags/create.blade.php
+++ b/src/resources/views/back/tags/create.blade.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @var \App\Models\Tag $tag
+ */
+$title = 'タグ登録';
+?>
+@extends('back.layouts.base')
+
+@section('content')
+<div class="card-header">{{ $title }}</div>
+<div class="card-body">
+    {{ Form::open(['route' => 'back.tags.store']) }}
+    @include('back.tags._form')
+    {{ Form::close() }}
+</div>
+@endsection

--- a/src/resources/views/back/tags/edit.blade.php
+++ b/src/resources/views/back/tags/edit.blade.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @var \App\Models\Tag $tag
+ */
+$title = 'タグ編集';
+?>
+@extends('back.layouts.base')
+
+@section('content')
+<div class="card-header">{{ $title }}</div>
+<div class="card-body">
+    {!! Form::model($tag, [
+        'route' => ['back.tags.update', $tag],
+        'method' => 'put'
+    ]) !!}
+    @include('back.tags._form')
+    {!! Form::close() !!}
+    <table class="table">
+        <tr>
+            <th>登録日時</th>
+            <td>{{ $tag->created_at }}</td>
+        </tr>
+        <tr>
+            <th>編集日時</th>
+            <td>{{ $tag->updated_at }}</td>
+        </tr>
+    </table>
+</div>
+@endsection

--- a/src/resources/views/back/tags/index.blade.php
+++ b/src/resources/views/back/tags/index.blade.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @var Illuminate\Pagination\LengthAwarePaginator|\App\Models\Tag[] $tags
+ */
+$title = 'タグ一覧';
+?>
+@extends('back.layouts.base')
+
+@section('content')
+<div class="card-header">{{ $title }}</div>
+<div class="card-body">
+    {{ link_to_route('back.tags.create', '新規登録', null, ['class' => 'btn btn-primary mb-3']) }}
+    @if(0 < $tags->count())
+        <table class="table table-striped table-bordered table-hover table-sm">
+            <thead>
+                <tr>
+                    <th scope="col">ID</th>
+                    <th scope="col">タグ名</th>
+                    <th scope="col">スラッグ</th>
+                    <th scope="col" style="width: 12em">編集</th>
+                </tr>
+            </thead>
+            <tbody>
+            @foreach($tags as $tag)
+                <tr>
+                    <td>{{ $tag->id }}</td>
+                    <td>{{ $tag->name }}</td>
+                    <td>{{ $tag->slug }}</td>
+                    <td class="d-flex justify-content-center">
+                        {{ link_to_route('back.tags.edit', '編集', $tag, [
+                            'class' => 'btn btn-secondary btn-sm m-1'
+                        ]) }}
+                        {{ Form::model($tag, [
+                            'route' => ['back.tags.destroy', $tag],
+                            'method' => 'delete'
+                        ]) }}
+                            {{ Form::submit('削除', [
+                                'onclick' => "return confirm('本当に削除しますか?')",
+                                'class' => 'btn btn-danger btn-sm m-1'
+                            ]) }}
+                        {{ Form::close() }}
+                    </td>
+                </tr>
+            @endforeach
+            </tbody>
+        </table>
+        <div class="d-flex justify-content-center">
+            {{ $tags->links() }}
+        </div>
+    @endif
+</div>
+@endsection

--- a/src/resources/views/front/posts/index.blade.php
+++ b/src/resources/views/front/posts/index.blade.php
@@ -8,6 +8,22 @@ $title = '投稿一覧';
  
 @section('content')
 <div class="card-header">{{ $title }}</div>
+<ul class="nav nav-pills mb-2">
+    <li class="nav-item">
+        {{ link_to_route('front.home', 'すべて', null, [
+            'class' => 'nav-link'.
+            (request()->segment(3) === null ? ' active' : '')
+        ]) }}
+    </li>
+    @foreach($tags as $tag)
+        <li class="nav-item">
+            {{ link_to_route('front.posts.index.tag', $tag->name, $tag->slug, [
+                'class' => 'nav-link'.
+                (request()->segment(3) === $tag->slug ? ' active' : '')
+            ]) }}
+        </li>
+    @endforeach
+</ul>
 <div class="card-body">
     @if($posts->count() <= 0)
         <p>表示する投稿はありません。</p>

--- a/src/routes/back.php
+++ b/src/routes/back.php
@@ -3,3 +3,5 @@ use Illuminate\Support\Facades\Route;
  
 Route::get('/', 'DashboardController')->name('dashboard');
 Route::resource('posts', PostController::class)->except('show');
+
+Route::resource('tags', TagController::class)->except('show');

--- a/src/routes/front.php
+++ b/src/routes/front.php
@@ -5,3 +5,5 @@ use Illuminate\Support\Facades\Route;
 
 Route::get('/', [PostController::class, 'index'])->name('home');
 Route::get('/posts/{id}', [PostController::class, 'show'])->name('posts.show');
+
+Route::get('posts/tag/{tagSlug}', [PostController::class, 'index'])->where('tagSlug', '[a-z]+')->name('posts.index.tag');


### PR DESCRIPTION
## 目的
タグの一覧を表示したり、新規登録・編集出来たり、タグを管理できるようにしたい。
投稿のタグごとの一覧を表示できるようにしたい。

## 実装内容
タグテーブルを作成しデータを登録
タグテーブルとポストテーブルを紐づけ
タグのCRUD機能の実装
投稿をタグごとに一覧表示できるように実装

## 期待動作
データベースにタグテーブルが作成できてデータが登録されている。
http://127.0.0.1:8001/admin/tags
にアクセスするとタグの一覧が表示される
タグの新規作成画面が表示できる
投稿の一覧画面でタグを選択すると、そのタグが付いている投稿の一覧を表示できる。

## 実行結果
DBeaverでデータベースを確認
![image](https://user-images.githubusercontent.com/107784486/189641063-8f7d92b7-71d9-4d45-8611-5259192bedb2.png)

http://127.0.0.1:8001/admin/tags
にアクセス
![image](https://user-images.githubusercontent.com/107784486/189641197-7a4b51ce-e4ec-4cb4-a617-f3958e4a3209.png)

タグの新規一覧画面
![image](https://user-images.githubusercontent.com/107784486/189641229-24d2c9a5-2a99-4bea-80a0-41aa87ffd518.png)

お知らせのタグが付いている投稿の一覧
![image](https://user-images.githubusercontent.com/107784486/189641395-7d7e9dfa-9026-4e58-af7c-cc3657f8b831.png)




