### PR TITLE
投稿の詳細ページにコメント一覧の表示・新規作成画面の作成

### DIFF
--- a/src/app/Http/Controllers/Back/CommentController.php
+++ b/src/app/Http/Controllers/Back/CommentController.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Http\Controllers\Back;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Models\Comment;
+use App\Models\Post;
+
+class CommentController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+         
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create($id)
+    {
+        $post = Post::publicFindById($id);
+        // dd($id);
+        return view('back.comments.create', compact('id', 'post'));
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request, int $id)
+    {
+        $comment = Comment::create($request->all());
+
+        if ($comment) {
+            return redirect()
+                ->route('back.comments.edit', $comment)
+                ->withSuccess('コメントを作成しました。');
+        } else {
+            return redirect()
+                ->route('back.comments.create')
+                ->withError('コメントの作成に失敗しました。');
+        }
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/src/app/Http/Controllers/Back/CommentController.php
+++ b/src/app/Http/Controllers/Back/CommentController.php
@@ -27,7 +27,6 @@ class CommentController extends Controller
     public function create($id)
     {
         $post = Post::publicFindById($id);
-        // dd($id);
         return view('back.comments.create', compact('id', 'post'));
     }
 

--- a/src/app/Http/Controllers/Back/PostController.php
+++ b/src/app/Http/Controllers/Back/PostController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\Post;
 use App\Models\Tag;
+use App\Models\Comment;
 use App\Http\Requests\PostRequest;
 
 class PostController extends Controller
@@ -60,14 +61,14 @@ class PostController extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function show($id)
+    public function show(int $id)
     {
         $post = Post::publicFindById($id);
-        // $comments = Comment::wherePostId($id)
-        //     ->orderBy('published_at', 'desc')
-        //     ->paginate(10);
-
-        return view('back.posts.show', compact('post'));
+        $comments = Comment::wherePostId($id)
+            ->orderBy('published_at', 'desc')
+            ->paginate(10);
+            
+        return view('back.posts.show', compact('post', 'comments'));
     }
 
     /**

--- a/src/app/Http/Controllers/Back/PostController.php
+++ b/src/app/Http/Controllers/Back/PostController.php
@@ -62,7 +62,12 @@ class PostController extends Controller
      */
     public function show($id)
     {
-        //
+        $post = Post::publicFindById($id);
+        // $comments = Comment::wherePostId($id)
+        //     ->orderBy('published_at', 'desc')
+        //     ->paginate(10);
+
+        return view('back.posts.show', compact('post'));
     }
 
     /**

--- a/src/resources/views/back/comments/_form.blade.php
+++ b/src/resources/views/back/comments/_form.blade.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @var \App\Models\Tag $tag
+ */
+?>
+<div class="form-group row">
+    {{ Form::label('comment', 'コメント', ['class' => 'col-sm-2 col-form-label']) }}
+    <div class="col-sm-10">
+        {{ Form::text('comment', null, [
+            'class' => 'form-control' . ($errors->has('comment') ? ' is-invalid' : ''),
+            'required'
+        ]) }}
+        @error('comment')
+            <div class="invalid-feedback">
+                {{ $message }}
+            </div>
+        @enderror
+    </div>
+</div>
+
+<div class="form-group row">
+    {{ Form::label('published_at', '公開日', ['class' => 'col-sm-2 col-form-label']) }}
+    <div class="col-sm-10">
+        {{ Form::datetime('published_at',
+            isset($comment->published_at)
+                ? $comment->published_at->format('Y-m-d H:i')
+                : now()->format('Y-m-d H:i'),
+        [
+            'class' => 'form-control' . ($errors->has('published_at') ? ' is-invalid' : '')
+        ]) }}
+        @error('published_at')
+            <span class="invalid-feedback" role="alert">
+                <strong>{{ $message }}</strong>
+            </span>
+        @enderror
+    </div>
+</div>
+
+<div class="form-group row">
+    <div class="col-sm-10">
+        <button type="submit" class="btn btn-primary">保存</button>
+        {{ link_to_route('back.posts.show', '一覧へ戻る', $post, ['class' => 'btn btn-secondary']) }}
+    </div>
+</div>

--- a/src/resources/views/back/comments/create.blade.php
+++ b/src/resources/views/back/comments/create.blade.php
@@ -1,0 +1,13 @@
+<?php
+$title = 'コメント作成';
+?>
+@extends('back.layouts.base')
+
+@section('content')
+<div class="card-header">{{ $title }}</div>
+<div class="card-body">
+    {{ Form::open(['route' => ['back.comments.store', $post->id]]) }}
+    @include('back.comments._form')
+    {{ Form::close() }}
+</div>
+@endsection

--- a/src/resources/views/back/layouts/base.blade.php
+++ b/src/resources/views/back/layouts/base.blade.php
@@ -44,6 +44,18 @@
             </div>
         </div>
     </main>
+    <main class="py-4">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-md-12">
+                    <x-back.alert />
+                    <div class="card">
+                        @yield('comment')
+                    </div>
+                </div>
+            </div>
+        </div>
+    </main>
 </div>
 <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" crossorigin="anonymous"></script>

--- a/src/resources/views/back/posts/index.blade.php
+++ b/src/resources/views/back/posts/index.blade.php
@@ -30,7 +30,6 @@ $title = '投稿一覧';
                     <td class="d-flex justify-content-center">
                         {{ link_to_route('back.posts.show', '詳細', $post, [
                             'class' => 'btn btn-secondary btn-sm m-1',
-                            'target' => '_blank'
                         ]) }}
                         {{ link_to_route('back.posts.edit', '編集', $post, [
                             'class' => 'btn btn-secondary btn-sm m-1'

--- a/src/resources/views/back/posts/index.blade.php
+++ b/src/resources/views/back/posts/index.blade.php
@@ -28,7 +28,7 @@ $title = '投稿一覧';
                     <td>{{ $post->published_format }}</td>
                     <td>{{ $post->user->name }}</td>
                     <td class="d-flex justify-content-center">
-                        {{ link_to_route('front.posts.show', '詳細', $post, [
+                        {{ link_to_route('back.posts.show', '詳細', $post, [
                             'class' => 'btn btn-secondary btn-sm m-1',
                             'target' => '_blank'
                         ]) }}

--- a/src/resources/views/back/posts/show.blade.php
+++ b/src/resources/views/back/posts/show.blade.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @var \App\Models\Post $post
+ */
+$title = '投稿詳細';
+?>
+@extends('back.layouts.base')
+ 
+@section('content')
+<div class="card-header">{{ $title }}</div>
+<div class="card-body">
+    <h2>{{ $post->title }}</h2>
+    <time>{{ $post->published_format  }}</time>
+    <div>{!! nl2br(e($post->body)) !!}</div>
+    {!! link_to_route(
+        'back.posts.index', '一覧へ戻る', null,
+        ['class' => 'btn btn-secondary'])
+    !!}
+</div>
+@endsection

--- a/src/resources/views/back/posts/show.blade.php
+++ b/src/resources/views/back/posts/show.blade.php
@@ -18,3 +18,48 @@ $title = '投稿詳細';
     !!}
 </div>
 @endsection
+ 
+@section('comment')
+<div class="card-header">コメント一覧</div>
+<div class="card-body">
+    {{ link_to_route('back.comments.create', 'コメント作成', $post, ['class' => 'btn btn-primary mb-3']) }}
+    @if(0 < $comments->count())
+        <table class="table table-striped table-bordered table-hover table-sm">
+            <thead>
+                <tr>
+                    <th scope="col">ID</th>
+                    <th scope="col">コメント</th>
+                    <th scope="col" style="width: 9em">公開日</th>
+                    <th scope="col" style="width: 12em">編集</th>
+                </tr>
+            </thead>
+            <tbody>
+            @foreach($comments as $comment)
+                <tr>
+                    <td>{{ $comment->id }}</td>
+                    <td>{{ $comment->comment }}</td>
+                    <td>{{ $comment->published_at->format('Y年m月d日') }}</td>
+                    <td class="d-flex justify-content-center">
+                        {{ link_to_route('back.posts.edit', '編集', $comment, [
+                            'class' => 'btn btn-secondary btn-sm m-1'
+                        ]) }}
+                        {{ Form::model($comment, [
+                            'route' => ['back.posts.destroy', $comment],
+                            'method' => 'delete'
+                        ]) }}
+                            {{ Form::submit('削除', [
+                                'onclick' => "return confirm('本当に削除しますか?')",
+                                'class' => 'btn btn-danger btn-sm m-1'
+                            ]) }}
+                        {{ Form::close() }}
+                    </td>
+                </tr>
+            @endforeach
+            </tbody>
+        </table>
+        <div class="d-flex justify-content-center">
+            {{ $comments->links() }}
+        </div>
+    @endif
+</div>
+@endsection

--- a/src/routes/back.php
+++ b/src/routes/back.php
@@ -1,7 +1,8 @@
 <?php
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Back\PostController;
  
 Route::get('/', 'DashboardController')->name('dashboard');
-Route::resource('posts', PostController::class)->except('show');
+Route::resource('posts', PostController::class);
 
 Route::resource('tags', TagController::class)->except('show');

--- a/src/routes/back.php
+++ b/src/routes/back.php
@@ -6,11 +6,6 @@ use App\Http\Controllers\Back\CommentController;
 Route::get('/', 'DashboardController')->name('dashboard');
 Route::resource('posts', PostController::class);
 
-// Route::get('posts/{id}/comments/create', [CommentController::class, 'create'])->name('comments.create');
-// Route::post('posts/{id}/comments/', [CommentController::class, 'store'])->name('comments.store');
-// // Route::get('posts/{id}/edit', [CommentController::class, 'edit'])->name('comments.edit');
-// // Route::get('posts/{id}/destroy', [CommentController::class, 'destroy'])->name('comments.destroy');
-
 Route::resource('posts/{id}/comments', CommentController::class)->except(['index', 'show']);
 
 Route::resource('tags', TagController::class)->except('show');

--- a/src/routes/back.php
+++ b/src/routes/back.php
@@ -1,8 +1,16 @@
 <?php
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Back\PostController;
+use App\Http\Controllers\Back\CommentController;
  
 Route::get('/', 'DashboardController')->name('dashboard');
 Route::resource('posts', PostController::class);
+
+// Route::get('posts/{id}/comments/create', [CommentController::class, 'create'])->name('comments.create');
+// Route::post('posts/{id}/comments/', [CommentController::class, 'store'])->name('comments.store');
+// // Route::get('posts/{id}/edit', [CommentController::class, 'edit'])->name('comments.edit');
+// // Route::get('posts/{id}/destroy', [CommentController::class, 'destroy'])->name('comments.destroy');
+
+Route::resource('posts/{id}/comments', CommentController::class)->except(['index', 'show']);
 
 Route::resource('tags', TagController::class)->except('show');


### PR DESCRIPTION
## 目的
投稿の管理画面側にもコメントの一覧を表示して、コメントの新規作成ができるようにしたい

## 実装内容
投稿の管理画面側に投稿の詳細ページを作成
投稿の詳細ページにコメントの一覧を表示
コメント新規作成画面の作成

## 期待動作
投稿の管理画面側でも投稿の詳細ページが見れるようになる
投稿の詳細ページにコメントの一覧が表示される
投稿の詳細ページからコメントを新規作成できる

## 実行結果
投稿の詳細ページ
<img width="479" alt="image" src="https://user-images.githubusercontent.com/107784486/192938205-63ec07c2-7a76-4895-b32d-98161680b3fe.png">

コメントの新規作成画面
<img width="480" alt="image" src="https://user-images.githubusercontent.com/107784486/192938276-e842262a-5873-400d-82ea-364eb82e1ff5.png">

